### PR TITLE
Added npm install step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM node:14-bullseye-slim
 # Set the working directory
 WORKDIR /kaguya
 
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install Node.js dependencies
+RUN npm install
+
 # Install Python, Git, Curl, and build dependencies
 RUN apt-get update && \
     apt-get install -y python3 python3-pip git curl build-essential gfortran && \


### PR DESCRIPTION
This PR adds a step to the Dockerfile to copy the package.json and package-lock.json files into the Docker image and run npm install. This ensures that all necessary Node.js dependencies, including the 'next' package, are installed in the Docker container. This resolves an issue where the 'next' command was not found when running the Docker container.