### PR TITLE
Fix 'next' command not found issue in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM node:14-bullseye-slim
 # Set the working directory
 WORKDIR /kaguya
 
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install Node.js dependencies
+RUN npm install
+
 # Install Python, Git, Curl, and build dependencies
 RUN apt-get update && \
     apt-get install -y python3 python3-pip git curl build-essential gfortran && \

--- a/docker.sh
+++ b/docker.sh
@@ -4,4 +4,4 @@
 docker build -t kaguya .
 
 # Run the Docker container with the --rm flag (automatically remove container on exit)
-docker run --shm-size=2g --rm -p 3000:3000 -v $(pwd):/kaguya kaguya
+docker run --shm-size=2g --rm -p 3000:3000 -v $(pwd):/kaguya -v /kaguya/node_modules kaguya


### PR DESCRIPTION
This PR updates the docker.sh script to create a separate Docker volume for the node_modules directory. This prevents the node_modules directory in the Docker container from being overwritten by the volume mount, allowing the node_modules directory to persist in the Docker container even if it does not exist on the host machine. This resolves an issue where the 'next' command was not found when running the Docker container.

Changes:
- Updated docker.sh to create a separate volume for node_modules

Testing:
- Rebuild the Docker image and run the Docker container using the updated docker.sh script. Verify that the 'next' command is found and the application starts as expected.
