### PR TITLE
Update docker.sh to add a check for existing image before building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ __pycache__/
 FILES/*
 .gitmodules
 !FILES/sample.txt
+
+# Ignore .last_build_timestamp because it stores the timestamp of the last Docker build and should not be version controlled.
+.last_build_timestamp

--- a/docker.sh
+++ b/docker.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 
-# Build the Docker image
-docker build -t kaguya .
+# Name of the image
+IMAGE_NAME="kaguya"
+
+# Check if the image already exists
+if [ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]; then
+  echo "Image does not exist. Building..."
+  # Build the Docker image
+  docker build -t $IMAGE_NAME .
+else
+  echo "Image exists. Starting container..."
+fi
 
 # Run the Docker container with the --rm flag (automatically remove container on exit)
-docker run --shm-size=2g --rm -p 3000:3000 -v $(pwd):/kaguya -v /kaguya/node_modules kaguya
+docker run --shm-size=2g --rm -p 3000:3000 -v $(pwd):/kaguya -v /kaguya/node_modules $IMAGE_NAME

--- a/docker.sh
+++ b/docker.sh
@@ -3,13 +3,21 @@
 # Name of the image
 IMAGE_NAME="kaguya"
 
-# Check if the image already exists
-if [ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ]; then
-  echo "Image does not exist. Building..."
+# File to store the timestamp of the last build
+TIMESTAMP_FILE=".last_build_timestamp"
+
+# Get the modification timestamp of Dockerfile
+MOD_TIMESTAMP=$(date -r Dockerfile +%s)
+
+# Check if the image already exists and if the timestamp has changed
+if [ "$(docker images -q $IMAGE_NAME 2> /dev/null)" == "" ] || [ ! -f "$TIMESTAMP_FILE" ] || [ "$MOD_TIMESTAMP" != "$(cat $TIMESTAMP_FILE)" ]; then
+  echo "Building the image..."
   # Build the Docker image
   docker build -t $IMAGE_NAME .
+  # Store the modification timestamp of Dockerfile
+  echo "$MOD_TIMESTAMP" > $TIMESTAMP_FILE
 else
-  echo "Image exists. Starting container..."
+  echo "Image exists and is up to date. Starting container..."
 fi
 
 # Run the Docker container with the --rm flag (automatically remove container on exit)


### PR DESCRIPTION
- Updated docker.sh to use the modification timestamp of Dockerfile to determine if the image needs to be rebuilt.
- Added .last_build_timestamp to .gitignore with a comment explaining why it should be ignored.