### PR TITLE
Added replaceAll parameter to update endpoint

### DIFF
--- a/pages/api/update.js
+++ b/pages/api/update.js
@@ -16,7 +16,7 @@ export default async function handler(req, res) {
   if (req.method === "POST") {
 
     // Extract the parameters from the request body
-    const { filePath, searchString, replacementString } = req.body;
+    const { filePath, searchString, replacementString, replaceAll } = req.body;
 
     // Ensure all required parameters are provided
     if (!filePath || searchString === undefined || replacementString === undefined) {
@@ -50,7 +50,7 @@ export default async function handler(req, res) {
       }
 
       // Perform the search and replace operation
-      const updatedContent = fileContent.replace(searchString, replacementString);
+      const updatedContent = replaceAll ? fileContent.split(searchString).join(replacementString) : fileContent.replace(searchString, replacementString);
 
       // Write the updated content back to the file
       fs.writeFileSync(fileAbsolutePath, updatedContent);

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -147,6 +147,9 @@ paths:
                 replacementString:
                   type: string
                   description: The string to replace the search string with
+                replaceAll:
+                  type: boolean
+                  description: Whether to replace all occurrences of the search string. Optional.y
       responses:
         "200":
           description: OK

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -149,7 +149,7 @@ paths:
                   description: The string to replace the search string with
                 replaceAll:
                   type: boolean
-                  description: Whether to replace all occurrences of the search string. Optional.y
+                  description: Whether to replace all occurrences of the search string. False by default
       responses:
         "200":
           description: OK


### PR DESCRIPTION
ChatGPT did most of the work here, editing the plugin itself.

It updated the JS fine with the existing `update` command.

It then tried to use the replaceAll param and got back `UnrecognizedKwargsError`. That seems to be an OpenAI thing. ChatGPT did some testing and it happened whenever it called an API endpoint with a param that's not in the openapi.yaml. Presumably that's a safety thing.

We went round in circles a bit here, thinking it was some kind of next.js cache! Then we realised we could make changes to the messages immediately.

The solution is updating the openapi.yaml file, then clicking "Refresh plugin" in the ChatGPT Plugin devtools sidebar (for anyone else reading this, you get to that from the ChatGPT settings on the bottom left.)

Once I'd done this, `replaceAll` worked fine and ChatGPT did some tests to check the functionality works fine.