### PR TITLE
Read multiple files should be a get operation #34

### DIFF
--- a/pages/api/readMultipleFiles.js
+++ b/pages/api/readMultipleFiles.js
@@ -17,8 +17,8 @@ export default function handler(req, res) {
     return;
   }
 
-  if (req.method === "POST") {
-    const { filePaths } = req.body;
+  if (req.method === "GET") {
+    const { filePaths } = req.query;
 
     if (!Array.isArray(filePaths)) {
       return res.status(400).json({ error: "filePaths must be an array" });

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -389,21 +389,18 @@ paths:
                     type: string
                     description: An error message
   /api/readMultipleFiles:
-    post:
+    get:
       operationId: readMultipleFiles
       summary: Read the content of multiple files
-      requestBody:
+      parameters:
+      - in: query
+        name: filePaths
+        schema:
+          type: array
+          items:
+            type: string
+        description: An array of file paths to read
         required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                filePaths:
-                  type: array
-                  items:
-                    type: string
-                  description: An array of file paths to read
       responses:
         '200':
           description: Successful operation


### PR DESCRIPTION
The differences are:

The HTTP method has been changed from post to get.
The requestBody section has been replaced with a parameters section. The filePaths parameter is now a query parameter (in: query) instead of being part of the request body. This is because GET requests should not have a body.

The changes are:

The condition if (req.method === "POST") has been changed to if (req.method === "GET") to handle GET requests instead of POST requests.
The filePaths parameter is now retrieved from req.query instead of req.body, because GET requests should not have a body.